### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,10 +9,10 @@ otpauth is One Time Password Authentication, which is usually called as
 two steps verification. You may have heard it from Google, Dropbox and
 etc.
 
-.. image:: https://pypip.in/wheel/otpauth/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/wheel/otpauth.svg?style=flat
    :target: https://pypi.python.org/pypi/otpauth/
    :alt: Wheel Status
-.. image:: https://pypip.in/version/otpauth/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/v/otpauth.svg?style=flat
    :target: https://pypi.python.org/pypi/otpauth/
    :alt: Latest Version
 .. image:: https://travis-ci.org/lepture/otpauth.svg?branch=master


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20otpauth))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `otpauth`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.